### PR TITLE
Political Parties and handle scraper errors

### DIFF
--- a/RepresentsMe.xcodeproj/project.pbxproj
+++ b/RepresentsMe.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		13287BB92220479B00622CD4 /* OfficialScraperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13287BB82220479B00622CD4 /* OfficialScraperTests.swift */; };
 		13287BBD222065D400622CD4 /* OfficialScraperTestsData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13287BBC222065D400622CD4 /* OfficialScraperTestsData.swift */; };
 		13287BC02220BEA300622CD4 /* apikey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13287BBA2220490E00622CD4 /* apikey.swift */; };
+		133BD33B223A76F00069279A /* PoliticalParty.swift in Sources */ = {isa = PBXBuildFile; fileRef = 133BD33A223A76F00069279A /* PoliticalParty.swift */; };
 		13527116221F74AC00442AA6 /* JSONData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13527111221F74AB00442AA6 /* JSONData.swift */; };
 		13527117221F74AC00442AA6 /* JSONOfficial.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13527112221F74AB00442AA6 /* JSONOfficial.swift */; };
 		13527118221F74AC00442AA6 /* OfficialScraper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13527113221F74AB00442AA6 /* OfficialScraper.swift */; };
@@ -59,6 +60,7 @@
 		13287BB82220479B00622CD4 /* OfficialScraperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfficialScraperTests.swift; sourceTree = "<group>"; };
 		13287BBA2220490E00622CD4 /* apikey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = apikey.swift; sourceTree = "<group>"; };
 		13287BBC222065D400622CD4 /* OfficialScraperTestsData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfficialScraperTestsData.swift; sourceTree = "<group>"; };
+		133BD33A223A76F00069279A /* PoliticalParty.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PoliticalParty.swift; sourceTree = "<group>"; };
 		13527111221F74AB00442AA6 /* JSONData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JSONData.swift; sourceTree = "<group>"; };
 		13527112221F74AB00442AA6 /* JSONOfficial.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JSONOfficial.swift; sourceTree = "<group>"; };
 		13527113221F74AB00442AA6 /* OfficialScraper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OfficialScraper.swift; sourceTree = "<group>"; };
@@ -137,6 +139,7 @@
 				3B9072C722309B2700B8A2F8 /* Address.swift */,
 				1352711F221F8AA200442AA6 /* Official.swift */,
 				13BD31BE223027E1000A6BEE /* FontAwesome */,
+				133BD33A223A76F00069279A /* PoliticalParty.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -385,6 +388,7 @@
 				3B9072C822309B2700B8A2F8 /* Address.swift in Sources */,
 				13527120221F8AA200442AA6 /* Official.swift in Sources */,
 				3B1EFD54221F06E9003176BF /* AppDelegate.swift in Sources */,
+				133BD33B223A76F00069279A /* PoliticalParty.swift in Sources */,
 				13BD31AE223020CD000A6BEE /* Enum.swift in Sources */,
 				3B1EFD5C221F06E9003176BF /* RepresentsMe.xcdatamodeld in Sources */,
 				16B6B2C622209D8100DB3A5B /* MapViewController.swift in Sources */,

--- a/RepresentsMe/Models/Official.swift
+++ b/RepresentsMe/Models/Official.swift
@@ -9,34 +9,10 @@
 import Foundation
 import UIKit
 
-let LIGHT_BLUE = UIColor(red: 64 / 255,
-                         green: 86 / 255,
-                         blue: 244 / 255,
-                         alpha: 1)
-let LIGHT_RED = UIColor(red: 206 / 255,
-                        green: 45 / 255,
-                        blue: 79 / 255,
-                        alpha: 1)
-
 let DEFAULT_NOT_LOADED = UIImage.fontAwesomeIcon(
     name: .userCircle,
     style: .solid,
     textColor: .gray,
-    size: PORTRAIT_SIZE)
-let DEFAULT_NON_PARTISAN = UIImage.fontAwesomeIcon(
-    name: .userCircle,
-    style: .solid,
-    textColor: .black,
-    size: PORTRAIT_SIZE)
-let DEFAULT_REPUBLICAN = UIImage.fontAwesomeIcon(
-    name: .userCircle,
-    style: .solid,
-    textColor: LIGHT_RED,
-    size: PORTRAIT_SIZE)
-let DEFAULT_DEMOCRAT = UIImage.fontAwesomeIcon(
-    name: .userCircle,
-    style: .solid,
-    textColor: LIGHT_BLUE,
     size: PORTRAIT_SIZE)
 
 /// Class containing the information avaliable for a government official.
@@ -46,7 +22,7 @@ class Official: Equatable, CustomStringConvertible {
     var name:String                     // The name of the official
     var photo:UIImage?                  // The cached photo of the official
     var photoURL:URL?                   // The photo url of the official
-    var party:String                    // The political party of the official
+    var party:PoliticalParty            // The political party of the official
     var addresses:[[String: String]]    // The addresses for the official
     var phones:[String]                 // The phones for the official
     var urls:[URL?]                     // The urls for the official
@@ -79,7 +55,7 @@ class Official: Equatable, CustomStringConvertible {
         self.index = index
         self.name = name
         self.photoURL = photoURL
-        self.party = party
+        self.party = PoliticalParty.determine(for: party)
         self.addresses = addresses
         self.phones = phones
         self.emails = emails
@@ -100,7 +76,7 @@ class Official: Equatable, CustomStringConvertible {
         self.index = index
         self.name = official.name
         self.photoURL = URL(string: official.photoUrl)
-        self.party = official.party
+        self.party = PoliticalParty.determine(for: official.party)
         self.addresses = official.address
         self.phones = official.phones
         self.urls = official.urls.map{URL(string: $0)}
@@ -206,14 +182,8 @@ class Official: Equatable, CustomStringConvertible {
             
             // If the photo does not exist or could not be downloaded,
             // set photo to empty
-            if self.party == "Republican Party" {
-                self.photo = DEFAULT_REPUBLICAN
-            } else if self.party == "Democratic Party" {
-                self.photo = DEFAULT_DEMOCRAT
-            } else {
-                self.photo = DEFAULT_NON_PARTISAN
-            }
-            
+            self.photo = self.party.image
+
             return completion(self, self.photo)
         }
     }

--- a/RepresentsMe/Models/Official.swift
+++ b/RepresentsMe/Models/Official.swift
@@ -35,36 +35,19 @@ class Official: Equatable, CustomStringConvertible {
         return repr()                   // official. Conforms class to
     }                                   // CustomStringConvertible protocol.
     
-    /// Creates an Official given the values for each field.
-    ///
-    /// - Parameter index:          The index of the official
-    /// - Parameter name:           The name of the official
-    /// - Parameter photoURL:       The URL to the photo of the official
-    /// - Parameter party:          The political party of the official
-    /// - Parameter addresses:      An Array of addresses for the official
-    /// - Parameter phones:         An Array of phone numbers for the official
-    /// - Parameter emails:         An Array of emails for the official
-    /// - Parameter urls:           An Array of URLs for the official
-    /// - Parameter socialMedia:    An Array of social media accounts
-    /// - Parameter office:         The name of the official's office
-    /// - Parameter division:       The name of the office's division
-    init(_ index:Int, _ name:String, _ photoURL:URL?, _ party:String,
-         _ addresses:[[String: String]], _ phones:[String], _ urls:[URL?],
-         _ emails:[String], _ socialMedia:[[String: String]],
-         _ office:String, _ division:String) {
-        self.index = index
-        self.name = name
-        self.photoURL = photoURL
-        self.party = PoliticalParty.determine(for: party)
-        self.addresses = addresses
-        self.phones = phones
-        self.emails = emails
-        self.urls = urls
-        self.socialMedia = socialMedia
-        self.office = office
-        self.division = division
+    init() {
+        self.index = -1
+        self.name = ""
+        self.party = PoliticalParty.unknown
+        self.addresses = [[:]]
+        self.phones = []
+        self.urls = []
+        self.emails = []
+        self.socialMedia = [[:]]
+        self.office = ""
+        self.division = ""
     }
-    
+
     /// Builds an Official
     ///
     /// - Parameter index:      the index of this Official in the JSON

--- a/RepresentsMe/Models/PoliticalParty.swift
+++ b/RepresentsMe/Models/PoliticalParty.swift
@@ -30,7 +30,11 @@ class PoliticalParty: Equatable {
         name: "Democrat",
         color: PoliticalParty.LIGHT_BLUE,
         aliases: ["Democrat", "Democratic", "Democratic Party"])
-    static let nonpartisan = PoliticalParty(name: "Nonpartisan", color: .black)
+    static let nonpartisan = PoliticalParty(
+        name: "Nonpartisan",
+        color: .black,
+        aliases: ["Nonpartisan", "none"])
+    static let unknown = PoliticalParty(name: "Unknown", color: .black)
     
     var name:String         // The name to display
     var image:UIImage       // The default image to use
@@ -48,7 +52,7 @@ class PoliticalParty: Equatable {
                                              style: .solid,
                                              textColor: color,
                                              size: PORTRAIT_SIZE)
-        self.aliases = aliases
+        self.aliases = aliases.map {$0.lowercased()}
     }
     
     /// Determines the PoliticalParty given an alias for the party.
@@ -57,6 +61,7 @@ class PoliticalParty: Equatable {
     ///
     /// - Returns: the PoliticalParty matching the given alias
     static func determine(for alias:String) -> PoliticalParty {
+        let alias = alias.lowercased()
         if PoliticalParty.republican.aliases.contains(alias) {
             return PoliticalParty.republican
         }
@@ -65,7 +70,11 @@ class PoliticalParty: Equatable {
             return PoliticalParty.democratic
         }
         
-        return nonpartisan
+        if PoliticalParty.nonpartisan.aliases.contains(alias) {
+            return PoliticalParty.nonpartisan
+        }
+        
+        return PoliticalParty.unknown
     }
     
     /// Compares two political parties for equality

--- a/RepresentsMe/Models/PoliticalParty.swift
+++ b/RepresentsMe/Models/PoliticalParty.swift
@@ -1,0 +1,80 @@
+//
+//  PoliticalParty.swift
+//  RepresentsMe
+//
+//  Created by Michael Tirtowidjojo on 3/14/19.
+//  Copyright © 2019 11foot8. All rights reserved.
+//
+
+import UIKit
+
+/// Represents the political party of an Official.
+class PoliticalParty: Equatable {
+
+    // Colors to use for default images
+    static let LIGHT_BLUE = UIColor(red: 64 / 255,
+                                    green: 86 / 255,
+                                    blue: 244 / 255,
+                                    alpha: 1)
+    static let LIGHT_RED = UIColor(red: 206 / 255,
+                                   green: 45 / 255,
+                                   blue: 79 / 255,
+                                   alpha: 1)
+    
+    // Singleton instances of the different parties for Officials to share
+    static let republican = PoliticalParty(
+        name: "Republican",
+        color: PoliticalParty.LIGHT_RED,
+        aliases: ["Republican", "Republican Party"])
+    static let democratic = PoliticalParty(
+        name: "Democrat",
+        color: PoliticalParty.LIGHT_BLUE,
+        aliases: ["Democrat", "Democratic", "Democratic Party"])
+    static let nonpartisan = PoliticalParty(name: "Nonpartisan", color: .black)
+    
+    var name:String         // The name to display
+    var image:UIImage       // The default image to use
+    var aliases:[String]    // Aliases for the party
+    
+    /// Creates a new Political Party loading in the default image for the
+    /// party.
+    ///
+    /// - Parameter name:       the name to display for the party
+    /// - Parameter color:      the color for the default image
+    /// - Parameter aliases:    the aliases for the party
+    private init(name:String, color:UIColor, aliases:[String] = []) {
+        self.name = name
+        self.image = UIImage.fontAwesomeIcon(name: .userCircle,
+                                             style: .solid,
+                                             textColor: color,
+                                             size: PORTRAIT_SIZE)
+        self.aliases = aliases
+    }
+    
+    /// Determines the PoliticalParty given an alias for the party.
+    ///
+    /// - Parameter for:    the alias for the party
+    ///
+    /// - Returns: the PoliticalParty matching the given alias
+    static func determine(for alias:String) -> PoliticalParty {
+        if PoliticalParty.republican.aliases.contains(alias) {
+            return PoliticalParty.republican
+        }
+        
+        if PoliticalParty.democratic.aliases.contains(alias) {
+            return PoliticalParty.democratic
+        }
+        
+        return nonpartisan
+    }
+    
+    /// Compares two political parties for equality
+    ///
+    /// - Parameter lhs:    the first PoliticalParty
+    /// - Parameter rhs:    the second PoliticalParty
+    ///
+    /// - Returns: true if lhs and rhs are the same object, false otherwise
+    static func == (lhs:PoliticalParty, rhs:PoliticalParty) -> Bool {
+        return lhs === rhs
+    }
+}

--- a/RepresentsMe/Scraper/OfficialScraper.swift
+++ b/RepresentsMe/Scraper/OfficialScraper.swift
@@ -44,7 +44,8 @@ class OfficialScraper {
         do {
             urlString = try buildURL(address: address.description, apikey: apikey)
         } catch {
-            return completion(nil, error as? ParserError)
+            // Failed to build the url, return an empty Array
+            return completion([], nil)
         }
 
         let url = URL(string: urlString!)
@@ -53,8 +54,7 @@ class OfficialScraper {
         URLSession.shared.dataTask(with: request) { data, response, error in
             if error != nil {
                 // Error occurred, abort
-                return completion(nil, ParserError.requestFailedError(
-                    error?.localizedDescription ?? "Request failed."))
+                return completion([], nil)
             }
             
             do {
@@ -62,8 +62,8 @@ class OfficialScraper {
                 let jsonData = try parseJSON(data: data!)
                 return completion(Official.buildOfficials(data: jsonData), nil)
             } catch {
-                // Error occurred while parsing JSON
-                return completion(nil, error as? ParserError)
+                // Error occurred while parsing JSON, return an empty Array
+                return completion([], nil)
             }
         }.resume()
     }

--- a/RepresentsMe/View Controllers/HomeViewController.swift
+++ b/RepresentsMe/View Controllers/HomeViewController.swift
@@ -32,15 +32,12 @@ class HomeViewController: UIViewController, UITableViewDelegate, UITableViewData
         navigationItem.title = "\(addr.city), \(addr.state)"
         OfficialScraper.getForAddress(address: addr, apikey: civic_api_key) {
             (officialList: [Official]?, error: ParserError?) in
-            if error == nil {
-                if let officialList = officialList {
-                    self.officials = officialList
-                    DispatchQueue.main.async {
-                        self.officialsTableView.reloadData()
-                    }
+            if error == nil, let officialList = officialList {
+                self.officials = officialList
+                DispatchQueue.main.async {
+                    self.officialsTableView.reloadData()
                 }
             }
-            // TODO: Handle ParserErrors
         }
     }
 

--- a/RepresentsMe/Views/OfficialCell.swift
+++ b/RepresentsMe/Views/OfficialCell.swift
@@ -21,7 +21,7 @@ class OfficialCell: UITableViewCell {
         didSet {
             nameLabel.text = official?.name
             officeLabel.text = official?.office
-            partyLabel.text = official?.party
+            partyLabel.text = official?.party.name
 
             portraitImageView.image = DEFAULT_NOT_LOADED
             official?.getPhoto(completion: { (photoOfficial, image) in

--- a/RepresentsMeTests/OfficialScraperTests.swift
+++ b/RepresentsMeTests/OfficialScraperTests.swift
@@ -10,6 +10,17 @@ import XCTest
 @testable import RepresentsMe
 
 class OfficialScraperTests: XCTestCase {
+    
+    let validAddress = Address(streetNumber: "2317",
+                               streetName: "Speedway",
+                               city: "Austin",
+                               state: "TX",
+                               zipcode: "78712")
+    let invalidAddress = Address(streetNumber: "invalid",
+                                 streetName: "",
+                                city: "",
+                                state: "",
+                                zipcode: "")
 
     override func setUp() {
         // Put setup code here. This method is called before the invocation of each test method in the class.
@@ -21,35 +32,33 @@ class OfficialScraperTests: XCTestCase {
 
     /// Test successful scraping of data
     func testScrapingData() {
-        let result = makeRequest(address: "2317 Speedway, Austin, TX 78712",
+        let result = makeRequest(address: validAddress,
                                  apikey: civic_api_key)
         XCTAssertNotNil(result.0)       // Assert no errors
         XCTAssertNil(result.1)          // Assert some result returned
     }
     
-    /// Test that an error is received if an invalid address is given
+    /// Test that an empty array is received if an invalid address is given
     func testInvalidAddress() {
-        let result = makeRequest(address: "invalid", apikey: civic_api_key)
+        let result = makeRequest(address: invalidAddress,
+                                 apikey: civic_api_key)
         let officials = result.0
         let error = result.1
         
-        if case .invalidAddressError = error! {
-            XCTAssertTrue(true)
-        } else {
-            XCTFail("Did not throw ParserError.invalidAddressError")
-        }
-        XCTAssertNil(officials)
+        XCTAssertNotNil(officials)
+        XCTAssertNil(error)
+        XCTAssertEqual(officials, [])
     }
     
-    /// Test that an error is received if an invalid api key is given
+    /// Test that an empty array is received if an invalid API key is given
     func testInvalidAPIKey() {
-        let result = makeRequest(address: "2317 Speedway, Austin, TX 78712",
+        let result = makeRequest(address: validAddress,
                                  apikey: "invalid")
         let officials = result.0
         let error = result.1
         
-        XCTAssertNil(error)
         XCTAssertNotNil(officials)
+        XCTAssertNil(error)
         XCTAssertEqual(officials, [])
     }
     
@@ -101,7 +110,7 @@ class OfficialScraperTests: XCTestCase {
     /// - Parameter apikey:     The apikey to use
     ///
     /// - Returns: a tuple with the resulting Officials and errors if any
-    func makeRequest(address:String, apikey:String,
+    func makeRequest(address:Address, apikey:String,
                      timeout:Double = 10) -> ([Official]?, ParserError?) {
         var error:ParserError?
         var officials:[Official]?

--- a/RepresentsMeTests/OfficialScraperTestsData.swift
+++ b/RepresentsMeTests/OfficialScraperTestsData.swift
@@ -93,7 +93,7 @@ class OfficialScraperTestsData {
 
 /// Extend Official with hardcoded values for creating officials when testing
 extension Official {
-    
+
     /// Creates an Official given the values for each field.
     ///
     /// - Parameter index:          The index of the official
@@ -116,7 +116,7 @@ extension Official {
         self.index = index
         self.name = name
         self.photoURL = URL(string: photoURL)
-        self.party = party
+        self.party = PoliticalParty.determine(for: party)
         self.addresses = addresses
         self.phones = phones
         self.emails = emails


### PR DESCRIPTION
This PR:
- Adds the `PoliticalParty` class that determines the party of an `Official` handling different aliases for a political party.
- Modifies the scraper to always return an empty `[Official]` and `nil` error if the scraper fails to parse the request.

closes #42 