### PR TITLE
Modified export event alert so that it allows user to open up calenda…

### DIFF
--- a/RepresentsMe/Sources/Utilities/UIViewControllerExt.swift
+++ b/RepresentsMe/Sources/Utilities/UIViewControllerExt.swift
@@ -44,4 +44,23 @@ extension UIViewController {
         // Present the alert
         self.present(alert, animated: true, completion: completion)
     }
+    
+    /// Presents an alert specific to when an event is exported. Takes user to the
+    /// calendar app if they so desire
+    ///
+    /// - Parameter date:      the date at which the exported event is taking place.
+    func exportEventAlert(date: Date) {
+        let interval = date.timeIntervalSinceReferenceDate
+        let alert = UIAlertController(
+            title: "Success",
+            message: "The event has been exported to your calendar. Would you like to open up the calendar app?",
+            preferredStyle: .alert)
+        alert.addAction(UIAlertAction(title: "OK", style: .default, handler: {(alert: UIAlertAction!) in
+            UIApplication.shared.open(NSURL(string: "calshow:\(interval)")! as URL)
+        }))
+        alert.addAction(UIAlertAction(title: "Cancel", style: .cancel, handler: nil))
+        
+        // Present the alert
+        self.present(alert, animated: true)
+    }
 }

--- a/RepresentsMe/Sources/Utilities/UIViewControllerExt.swift
+++ b/RepresentsMe/Sources/Utilities/UIViewControllerExt.swift
@@ -44,23 +44,4 @@ extension UIViewController {
         // Present the alert
         self.present(alert, animated: true, completion: completion)
     }
-    
-    /// Presents an alert specific to when an event is exported. Takes user to the
-    /// calendar app if they so desire
-    ///
-    /// - Parameter date:      the date at which the exported event is taking place.
-    func exportEventAlert(date: Date) {
-        let interval = date.timeIntervalSinceReferenceDate
-        let alert = UIAlertController(
-            title: "Success",
-            message: "The event has been exported to your calendar. Would you like to open up the calendar app?",
-            preferredStyle: .alert)
-        alert.addAction(UIAlertAction(title: "OK", style: .default, handler: {(alert: UIAlertAction!) in
-            UIApplication.shared.open(NSURL(string: "calshow:\(interval)")! as URL)
-        }))
-        alert.addAction(UIAlertAction(title: "Cancel", style: .cancel, handler: nil))
-        
-        // Present the alert
-        self.present(alert, animated: true)
-    }
 }

--- a/RepresentsMe/ViewControllers/Events/EventDetails/EventDetailsViewController.swift
+++ b/RepresentsMe/ViewControllers/Events/EventDetails/EventDetailsViewController.swift
@@ -317,10 +317,29 @@ class EventDetailsViewController: UIViewController {
         // If succeeded, give the user the option to open up the calendar app.g
         do {
             try eventStore.save(event,span:.thisEvent)
-            self.exportEventAlert(date: startDate as Date)
+            exportEventAlert(date: startDate as Date)
         } catch {
             self.alert(title: "Error", message: "Unable to export event to calendar")
         }
+    }
+    
+    /// Presents an alert specific to when an event is exported. Takes user to the
+    /// calendar app if they so desire
+    ///
+    /// - Parameter date:      the date at which the exported event is taking place.
+    private func exportEventAlert(date: Date) {
+        let interval = date.timeIntervalSinceReferenceDate
+        let alert = UIAlertController(
+            title: "Success",
+            message: "The event has been exported to your calendar. Would you like to open up the calendar app?",
+            preferredStyle: .alert)
+        alert.addAction(UIAlertAction(title: "OK", style: .default, handler: {(alert: UIAlertAction!) in
+            UIApplication.shared.open(NSURL(string: "calshow:\(interval)")! as URL)
+        }))
+        alert.addAction(UIAlertAction(title: "Cancel", style: .cancel, handler: nil))
+        
+        // Present the alert
+        self.present(alert, animated: true)
     }
     
     

--- a/RepresentsMe/ViewControllers/Events/EventDetails/EventDetailsViewController.swift
+++ b/RepresentsMe/ViewControllers/Events/EventDetails/EventDetailsViewController.swift
@@ -314,9 +314,10 @@ class EventDetailsViewController: UIViewController {
         event.calendar = eventStore.defaultCalendarForNewEvents
         
         // Alert the user to let them know if the export succeeded or failed
+        // If succeeded, give the user the option to open up the calendar app.g
         do {
             try eventStore.save(event,span:.thisEvent)
-            self.alert(title: "Success!", message: "The event has been exported to your calendar")
+            self.exportEventAlert(date: startDate as Date)
         } catch {
             self.alert(title: "Error", message: "Unable to export event to calendar")
         }


### PR DESCRIPTION
…r app if they want. When calendar app is opened up, it goes directly to the day of the exported event.
![Simulator Screen Shot - iPhone Xʀ - 2019-04-30 at 12 15 48](https://user-images.githubusercontent.com/13663809/56980352-bda0f780-6b41-11e9-889a-f007951372e8.png)
![Simulator Screen Shot - iPhone Xʀ - 2019-04-30 at 12 15 38](https://user-images.githubusercontent.com/13663809/56980353-be398e00-6b41-11e9-905b-a4ca16098a06.png)

